### PR TITLE
WIP: Use updated API in VTK 6.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
 
 before_install:
   # download VTK
-  - wget http://midas3.kitware.com/midas/download/bitstream/366970/vtk-precise64-118242.tar.gz -O vtk-precise64.tar.gz
-  - tar xzvf vtk-precise64.tar.gz -C ~
+  #- wget http://midas3.kitware.com/midas/download/bitstream/366970/vtk-precise64-118242.tar.gz -O vtk-precise64.tar.gz
+  #- tar xzvf vtk-precise64.tar.gz -C ~
   # Setup anaconda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -22,7 +22,7 @@ before_install:
   - conda update --yes conda
 
 install: # Install packages
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose pandas
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose pandas vtk
   # Coverage packages are on my binstar channel
   - "pip install python-coveralls coverage nose-cov"
   - "pip install profilehooks"

--- a/mindboggle/guts/mesh.py
+++ b/mindboggle/guts/mesh.py
@@ -455,10 +455,10 @@ def find_adjacent_faces(faces):
     Returns
     -------
     adjacent_faces: list of pairs of lists of three integers
-        list 1 indexes three faces adjacent to the three face's edges; 
+        list 1 indexes three faces adjacent to the three face's edges;
         list 2 indexes three vertices opposite the adjacent faces:
         adjacent_faces[i]: two lists, each of length 3
-        adjacent_faces[i][0] = [face0, face1, face2]: 
+        adjacent_faces[i][0] = [face0, face1, face2]:
                                 face0 is the neighbor of face i facing vertex0
         adjacent_faces[i][1] = [vertex0, vertex1, vertex2], which is face i:
                                 vertex0 is the vertex of face0 not in face i
@@ -827,7 +827,7 @@ def decimate(points, faces, reduction=0.75, smooth_steps=25,
     # We want to preserve topology (not let any cracks form).
     # This may limit the total reduction possible.
     decimate = vtk.vtkDecimatePro()
-    decimate.SetInput(polydata)
+    decimate.SetInputData(polydata)
     decimate.SetTargetReduction(reduction)
     decimate.PreserveTopologyOn()
 
@@ -842,17 +842,17 @@ def decimate(points, faces, reduction=0.75, smooth_steps=25,
         output_vtk = None
     if smooth_steps > 0:
         smoother = vtk.vtkSmoothPolyDataFilter()
-        smoother.SetInput(decimate.GetOutput())
+        smoother.SetInputData(decimate.GetOutput())
         smoother.SetNumberOfIterations(smooth_steps)
         smoother.Update()
         out = smoother.GetOutput()
         if save_vtk:
-            exporter.SetInput(smoother.GetOutput())
+            exporter.SetInputData(smoother.GetOutput())
     else:
         decimate.Update()
         out = decimate.GetOutput()
         if save_vtk:
-            exporter.SetInput(decimate.GetOutput())
+            exporter.SetInputData(decimate.GetOutput())
 
     #-------------------------------------------------------------------------
     # Export output:

--- a/surface_cpp_tools/FsSurfaceReader.cpp
+++ b/surface_cpp_tools/FsSurfaceReader.cpp
@@ -113,7 +113,7 @@ FsSurfaceReader::FsSurfaceReader(char *fileName)
     pd->PrintSelf(cout,indent);
 
     vtkPolyDataNormals *pdn = vtkPolyDataNormals::New();
-    pdn->SetInput(pd);
+    pdn->SetInputData(pd);
     pdn->SetFeatureAngle(90);
     pdn->SplittingOff();
     pdn->Update();
@@ -125,7 +125,7 @@ FsSurfaceReader::FsSurfaceReader(char *fileName)
     m_mesh->DeepCopy(pdn->GetOutput());
 
 //    vtkPolyDataWriter* pdw = vtkPolyDataWriter::New();
-//    pdw->SetInput(m_mesh);
+//    pdw->SetInputData(m_mesh);
 //    pdw->SetFileName("test.vtk");
 //    pdw->Write();
 //    pdw->Update();


### PR DESCRIPTION
This PR fixes what looks like a change to the VTK API. 

When running the VTK decimate functions using version 6.3.0 installed via conda on Mac and Ubuntu I received the following error:
```
...
Reduced 266798 to 6486 triangular faces
  Scalar 35: 3368 vertices
('Downsampling vtk files.',)
Load "scalars" scalars from lh_1.vtk
Traceback (most recent call last):
  File "get_data.py", line 46, in <module>
    sample_rate=float(args['sample_rate']))
  File "/Users/nicholsn/Repos/roygbiv/roygbiv/__init__.py", line 105, in freesurfer_annot_to_vtks
    downsample_vtk(vtk_file, sample_rate=sample_rate)
  File "/Users/nicholsn/Repos/roygbiv/roygbiv/__init__.py", line 28, in downsample_vtk
    decimate_file(vtk_file, reduction=1 - sample_rate, output_vtk=vtk_file, save_vtk=True, smooth_steps=0)
  File "/Users/nicholsn/miniconda/envs/roygbiv/lib/python2.7/site-packages/mindboggle/guts/mesh.py", line 940, in decimate_file
    save_vtk, output_vtk)
  File "/Users/nicholsn/miniconda/envs/roygbiv/lib/python2.7/site-packages/mindboggle/guts/mesh.py", line 830, in decimate
    decimate.SetInput(polydata)
AttributeError: SetInput
```
Updating to use `SetInputData` seems to have fixed the error.