### PR TITLE
Fix hard-coded install paths so that cmake PREFIX is honoured

### DIFF
--- a/vtk_cpp_tools/CMakeLists.txt
+++ b/vtk_cpp_tools/CMakeLists.txt
@@ -50,8 +50,8 @@ add_library(
 MeshAnalyser MeshAnalyser.cpp
 )
 install(TARGETS MeshAnalyser
-        LIBRARY DESTINATION /lib
-        ARCHIVE DESTINATION /lib)
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
 
 add_library(
 FsSurfaceReader FsSurfaceReader.cpp

--- a/vtk_cpp_tools/area/CMakeLists.txt
+++ b/vtk_cpp_tools/area/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(
 PointAreaMain PointAreaMain.cpp
 )
 install(TARGETS PointAreaMain
-    RUNTIME DESTINATION /bin)
+    RUNTIME DESTINATION bin)
 
 target_link_libraries(
 PointAreaMain

--- a/vtk_cpp_tools/curvature/CMakeLists.txt
+++ b/vtk_cpp_tools/curvature/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(
 CurvatureMain CurvatureMain.cpp
 )
 install(TARGETS CurvatureMain
-    RUNTIME DESTINATION /bin)
+    RUNTIME DESTINATION bin)
 
 target_link_libraries(
 CurvatureMain

--- a/vtk_cpp_tools/geodesic_depth/CMakeLists.txt
+++ b/vtk_cpp_tools/geodesic_depth/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(
 GeodesicDepthMain GeodesicDepthMain.cpp
 )
 install(TARGETS GeodesicDepthMain
-    RUNTIME DESTINATION /bin)
+    RUNTIME DESTINATION bin)
 
 target_link_libraries(
 GeodesicDepthMain

--- a/vtk_cpp_tools/gradient/CMakeLists.txt
+++ b/vtk_cpp_tools/gradient/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(
 GradientMain GradientMain.cpp
 )
 install(TARGETS GradientMain
-    RUNTIME DESTINATION /bin)
+    RUNTIME DESTINATION bin)
 
 target_link_libraries(
 GradientMain

--- a/vtk_cpp_tools/medial_surfaces/CMakeLists.txt
+++ b/vtk_cpp_tools/medial_surfaces/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(
 MedialSurfaceMain MedialSurfaceMain.cpp
 )
 install(TARGETS MedialSurfaceMain
-    RUNTIME DESTINATION /bin)
+    RUNTIME DESTINATION bin)
 
 target_link_libraries(
 MedialSurfaceMain

--- a/vtk_cpp_tools/surface_overlap/CMakeLists.txt
+++ b/vtk_cpp_tools/surface_overlap/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(
 SurfaceOverlapMain SurfaceOverlapMain.cpp
 )
 install(TARGETS SurfaceOverlapMain
-    RUNTIME DESTINATION /bin)
+    RUNTIME DESTINATION bin)
 
 target_link_libraries(
 SurfaceOverlapMain

--- a/vtk_cpp_tools/travel_depth/CMakeLists.txt
+++ b/vtk_cpp_tools/travel_depth/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(
 TravelDepthMain TravelDepthMain.cpp
 )
 install(TARGETS TravelDepthMain
-    RUNTIME DESTINATION /bin)
+    RUNTIME DESTINATION bin)
 
 target_link_libraries(
 TravelDepthMain


### PR DESCRIPTION
This fixes the install locations so that if I set a CMAKE install prefix it is honoured.