### PR TITLE
Convert all readers to generic mesh file format readers

### DIFF
--- a/vtk_cpp_tools/area/PointAreaMain.cpp
+++ b/vtk_cpp_tools/area/PointAreaMain.cpp
@@ -1,11 +1,27 @@
 #include "../PointAreaComputer.h"
 #include "../MeshAnalyser.h"
 
+#include <vtkPolyData.h>
 #include <vtkPolyDataReader.h>
+#include <vtkSmartPointer.h>
+#include <vtkMNIObjectReader.h>
+#include <vtkSTLReader.h>
+#include <vtksys/SystemTools.hxx>
 
 #include <iostream>
 #include <fstream>
 #include <stdio.h>
+
+template<class TReader> vtkPolyData *ReadObject(const char*fileName)
+{
+  vtkSmartPointer<TReader> reader =
+    vtkSmartPointer<TReader>::New();
+  reader->SetFileName(fileName);
+
+  reader->Update();
+  reader->GetOutput()->Register(reader);
+  return reader->GetOutput();
+}
 
 void print_help()
 {
@@ -17,18 +33,21 @@ void print_help()
 int main(int argc, char** argv)
 {
     time_t start= time(NULL);
+    vtkPolyData *dataSet;
+    std::string extension =
+      vtksys::SystemTools::GetFilenameLastExtension(argv[1]);
+    if (extension == ".vtk")
+      dataSet = ReadObject<vtkPolyDataReader> (argv[1]);
+    else if (extension == ".obj")
+      dataSet = ReadObject<vtkMNIObjectReader> (argv[1]);
+    else if (extension == ".stl")
+      dataSet = ReadObject<vtkSTLReader> (argv[1]);
 
-    vtkPolyDataReader* reader = vtkPolyDataReader::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
 
-    PointAreaComputer* area = new PointAreaComputer(reader->GetOutput());
+    PointAreaComputer* area = new PointAreaComputer(dataSet);
     area->ComputeArea();
     area->WriteIntoFile(argv[2]);
 
     cout<<"Elapsed time (area): "<<time(NULL)-start<<" s"<<endl;
     return 0;
 }
-
-
-

--- a/vtk_cpp_tools/curvature/CurvatureMain.cpp
+++ b/vtk_cpp_tools/curvature/CurvatureMain.cpp
@@ -162,6 +162,3 @@ int main(int argc, char** argv)
     cout<<"Elapsed time: "<<time(NULL)-start<<" s"<<endl;
     return 0;
 }
-
-
-

--- a/vtk_cpp_tools/geodesic_depth/GeodesicDepthMain.cpp
+++ b/vtk_cpp_tools/geodesic_depth/GeodesicDepthMain.cpp
@@ -16,7 +16,7 @@ int main(int argc, char** argv)
     MeshAnalyser* depthComputer = new MeshAnalyser(argv[1]);
     depthComputer->ComputeGeodesicDepthFromClosed(false);
     depthComputer->WriteIntoFile(argv[2],(char*)"geoDepth");
-    
+
     if(argc > 3) {
         depthComputer->WriteIntoFile(argv[3],(char*)"closed");
     }
@@ -24,6 +24,3 @@ int main(int argc, char** argv)
     cout<<"Elapsed time (geodesic depth): "<<time(NULL)-start<<" s"<<endl;
     return 0;
 }
-
-
-

--- a/vtk_cpp_tools/gradient/GradientMain.cpp
+++ b/vtk_cpp_tools/gradient/GradientMain.cpp
@@ -1,10 +1,27 @@
 #include "../GradientComputer.h"
 
+#include <vtkPolyData.h>
 #include <vtkPolyDataReader.h>
+#include <vtkSmartPointer.h>
+#include <vtkMNIObjectReader.h>
+#include <vtkSTLReader.h>
+#include <vtksys/SystemTools.hxx>
+
 
 #include <iostream>
 #include <fstream>
 #include <stdio.h>
+
+template<class TReader> vtkPolyData *ReadObject(const char*fileName)
+{
+  vtkSmartPointer<TReader> reader =
+    vtkSmartPointer<TReader>::New();
+  reader->SetFileName(fileName);
+
+  reader->Update();
+  reader->GetOutput()->Register(reader);
+  return reader->GetOutput();
+}
 
 void print_help()
 {
@@ -16,18 +33,20 @@ void print_help()
 int main(int argc, char** argv)
 {
     time_t start= time(NULL);
+    vtkPolyData *dataSet;
+    std::string extension =
+      vtksys::SystemTools::GetFilenameLastExtension(argv[1]);
+    if (extension == ".vtk")
+      dataSet = ReadObject<vtkPolyDataReader> (argv[1]);
+    else if (extension == ".obj")
+      dataSet = ReadObject<vtkMNIObjectReader> (argv[1]);
+    else if (extension == ".stl")
+      dataSet = ReadObject<vtkSTLReader> (argv[1]);
 
-    vtkPolyDataReader* reader = vtkPolyDataReader::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
-
-    GradientComputer* area = new GradientComputer(reader->GetOutput());
+    GradientComputer* area = new GradientComputer(dataSet);
     area->ComputeGradient();
     area->WriteIntoFile(argv[2]);
 
     cout<<"Elapsed time (area): "<<time(NULL)-start<<" s"<<endl;
     return 0;
 }
-
-
-

--- a/vtk_cpp_tools/medial_surfaces/MedialSurfaceMain.cpp
+++ b/vtk_cpp_tools/medial_surfaces/MedialSurfaceMain.cpp
@@ -1,30 +1,59 @@
 #include "MedialSurfaceComputer.h"
 
+#include <vtkPolyData.h>
 #include <vtkPolyDataReader.h>
+#include <vtkSmartPointer.h>
+#include <vtkMNIObjectReader.h>
+#include <vtkSTLReader.h>
+#include <vtksys/SystemTools.hxx>
+
 
 #include <iostream>
 #include <fstream>
 #include <stdio.h>
 
+template<class TReader> vtkPolyData *ReadObject(const char*fileName)
+{
+  vtkSmartPointer<TReader> reader =
+    vtkSmartPointer<TReader>::New();
+  reader->SetFileName(fileName);
+
+  reader->Update();
+  reader->GetOutput()->Register(reader);
+  return reader->GetOutput();
+}
+
 int main(int argc, char** argv)
 {
     time_t start= time(NULL);
 
-    vtkPolyDataReader* travelReader = vtkPolyDataReader::New();
-    travelReader->SetFileName(argv[1]);
-    travelReader->Update();
+    vtkPolyData* travelData;
+    vtkPolyData* fundiData;
 
-    vtkPolyDataReader* fundiReader = vtkPolyDataReader::New();
-    fundiReader->SetFileName(argv[2]);
-    fundiReader->Update();
+    std::string extension1 =
+      vtksys::SystemTools::GetFilenameLastExtension(argv[1]);
+    std::string extension2 =
+      vtksys::SystemTools::GetFilenameLastExtension(argv[2]);
 
-    MedialSurfaceComputer* msc = new MedialSurfaceComputer( travelReader->GetOutput(), fundiReader->GetOutput() );
+      if (extension1 == ".vtk")
+        travelData = ReadObject<vtkPolyDataReader> (argv[1]);
+      else if (extension1 == ".obj")
+        travelData = ReadObject<vtkMNIObjectReader> (argv[1]);
+      else if (extension1 == ".stl")
+        travelData = ReadObject<vtkSTLReader> (argv[1]);
+
+      if (extension2 == ".vtk")
+        fundiData = ReadObject<vtkPolyDataReader> (argv[2]);
+      else if (extension2 == ".obj")
+        fundiData = ReadObject<vtkMNIObjectReader> (argv[2]);
+      else if (extension2 == ".stl")
+        fundiData = ReadObject<vtkSTLReader> (argv[2]);
+
+
+    MedialSurfaceComputer* msc = new MedialSurfaceComputer( travelData, fundiData );
 
     msc->WriteIntoFile(argv[3]);
 
     cout<<"Elapsed time (meshTest): "<<time(NULL)-start<<" s"<<endl;
     return 0;
 }
-
-
-

--- a/vtk_cpp_tools/surface_overlap/SurfaceOverlapMain.cpp
+++ b/vtk_cpp_tools/surface_overlap/SurfaceOverlapMain.cpp
@@ -1,10 +1,27 @@
 #include "../Overlap.h"
 
+#include <vtkPolyData.h>
 #include <vtkPolyDataReader.h>
+#include <vtkSmartPointer.h>
+#include <vtkMNIObjectReader.h>
+#include <vtkSTLReader.h>
+#include <vtksys/SystemTools.hxx>
+
 
 #include <iostream>
 #include <fstream>
 #include <stdio.h>
+
+template<class TReader> vtkPolyData *ReadObject(const char*fileName)
+{
+  vtkSmartPointer<TReader> reader =
+    vtkSmartPointer<TReader>::New();
+  reader->SetFileName(fileName);
+
+  reader->Update();
+  reader->GetOutput()->Register(reader);
+  return reader->GetOutput();
+}
 
 void print_help()
 {
@@ -17,24 +34,34 @@ int main(int argc, char** argv)
 {
     time_t start= time(NULL);
 
-    vtkPolyDataReader* reader1 = vtkPolyDataReader::New();
-    reader1->SetFileName(argv[1]);
-    reader1->Update();
+    vtkPolyData* data1;
+    vtkPolyData* data2;
 
-    vtkPolyDataReader* reader2 = vtkPolyDataReader::New();
-    reader2->SetFileName(argv[2]);
-    reader2->Update();
+    std::string extension1 =
+      vtksys::SystemTools::GetFilenameLastExtension(argv[1]);
+    std::string extension2 =
+      vtksys::SystemTools::GetFilenameLastExtension(argv[2]);
 
-    Overlap* surfOverlap = new Overlap(reader1->GetOutput(), reader2->GetOutput());
+      if (extension1 == ".vtk")
+        data1 = ReadObject<vtkPolyDataReader> (argv[1]);
+      else if (extension1 == ".obj")
+        data1 = ReadObject<vtkMNIObjectReader> (argv[1]);
+      else if (extension1 == ".stl")
+        data1 = ReadObject<vtkSTLReader> (argv[1]);
+
+      if (extension2 == ".vtk")
+        data2 = ReadObject<vtkPolyDataReader> (argv[2]);
+      else if (extension2 == ".obj")
+        data2 = ReadObject<vtkMNIObjectReader> (argv[2]);
+      else if (extension2 == ".stl")
+        data2 = ReadObject<vtkSTLReader> (argv[2]);
+
+
+    Overlap* surfOverlap = new Overlap(data1, data2);
     surfOverlap->ComputeOverlap();
     surfOverlap->WriteIntoFile(argv[3]);
-
-
 
 
     cout<<"Elapsed time (meshTest): "<<time(NULL)-start<<" s"<<endl;
     return 0;
 }
-
-
-

--- a/vtk_cpp_tools/travel_depth/TravelDepthMain.cpp
+++ b/vtk_cpp_tools/travel_depth/TravelDepthMain.cpp
@@ -59,15 +59,12 @@ int main(int argc, char** argv)
     MeshAnalyser* depthComputer = new MeshAnalyser(argv[argc-2]);
     depthComputer->ComputeTravelDepthFromClosed(normalized);
     depthComputer->WriteIntoFile(argv[argc-1],(char*)"depth");
-    
+
     if(wrapperExported) {
             depthComputer->WriteIntoFile(argv[wrapperNameId],(char*)"closed");
     }
-    
+
 
     cout<<"Elapsed time (meshTest): "<<time(NULL)-start<<" s"<<endl;
     return 0;
 }
-
-
-


### PR DESCRIPTION
Rather than hard-coding the polydata file format, I have adapted the readers to accept vtk, stl and MNI object format.