### PR TITLE
BUG: Missing vtk modules

### DIFF
--- a/vtk_cpp_tools/CMakeLists.txt
+++ b/vtk_cpp_tools/CMakeLists.txt
@@ -5,7 +5,7 @@ project(mindboggle_surfaces)
 ## "cmake .. -DVTK_DIR:STRING=/Users/arno/anaconda/lib/cmake/vtk-7.0"
 #set(VTK_DIR "/Users/arno/anaconda/lib/cmake/vtk-7.0")
 #find_package(VTK REQUIRED NO_MODULE)
-find_package(VTK 7.0 COMPONENTS vtkInteractionStyle vtkRenderingFreeType vtkRenderingOpenGL2 vtkRenderingVolumeOpenGL2 NO_MODULE)
+find_package(VTK 7.0 COMPONENTS vtkInteractionStyle vtkRenderingFreeType vtkRenderingOpenGL2 vtkRenderingVolumeOpenGL2 vtkIOLegacy vtkIOMINC vtkIOGeometry vtkImagingStencil vtkImagingMorphological vtkFiltersModeling NO_MODULE)
 include(${VTK_USE_FILE})
 
 #if(COMMAND CMAKE_POLICY)


### PR DESCRIPTION
The following vtk modules are referenced but missing from the COMPONENTS list:

vtkIOLegacy
vtkIOMINC
vtkIOGeometry
vtkImagingStencil
vtkImagingMorphological
vtkFiltersModeling