### PR TITLE
move import of etelemetry inside try block

### DIFF
--- a/mindboggle/__init__.py
+++ b/mindboggle/__init__.py
@@ -18,12 +18,11 @@ else:
 # object imports
 #from .blah import blah, blah
 
-import etelemetry
-
 INIT_MSG = "Running {packname} version {version} (latest: {latest})".format
 latest = {"version": 'Unknown'}
 try:
     from .version import __version__
+    import etelemetry
     latest = etelemetry.get_project("nipy/mindboggle")
 except Exception as e:
     print("Could not check for version updates: ", e)


### PR DESCRIPTION
In order to ingest the mindboggle parcellation labels into the NIF Ontology we run the following `from mindboggle.mio.labels import DKTprotocol as dkt`, which has no dependencies, and thus can be run by simply cloning this repository and not having to bother with installing a bunch of dependencies. Importing a dependency in the top level __init__ breaks this convenient behavior and also adds a network roundtrip for what should be a much simpler operation. This commit moves the etelemetry import inside the try/except block so that failure to import etelemetry does not prevent accessing static information in labels.py.